### PR TITLE
Add `--force` flag to idstools-rulecat

### DIFF
--- a/so-idstools/entrypoint.sh
+++ b/so-idstools/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd /opt/so/idstools/etc  || exit
 
-idstools-rulecat
+idstools-rulecat --force
 
 while true; do sleep 1; done


### PR DESCRIPTION
This forces idstools to pull from the url each time, which prevents it from clearing all.rules if idstools-rulecat is run twice within 15 minutes by any method (either restarting the container or running so-rule-update)