### PR TITLE
Set sigmac to use keyword for message

### DIFF
--- a/so-soctopus/so-soctopus/playbook.py
+++ b/so-soctopus/so-soctopus/playbook.py
@@ -512,7 +512,7 @@ def sigmac_generate(sigma):
     temp_file.seek(0)
 
     sigmac_output = subprocess.run(["sigmac", "-t", "es-qs", "-c", "playbook/sysmon.yml",
-                                    "-c", "playbook/securityonion-baseline.yml", "--backend-option", "keyword_whitelist=source.ip,destination.ip,source.port,destination.port", "--backend-option", "keyword_field=.keyword", "--backend-option", "analyzed_sub_field_name=.security", "--backend-option", "wildcard_use_keyword=false", temp_file.name],
+                                    "-c", "playbook/securityonion-baseline.yml", "--backend-option", "keyword_whitelist=source.ip,destination.ip,source.port,destination.port,message,rule.uuid", "--backend-option", "keyword_field=.keyword", "--backend-option", "analyzed_sub_field_name=.security", "--backend-option", "wildcard_use_keyword=false", temp_file.name],
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='ascii')
 
     es_query = sigmac_output.stdout.strip() + sigmac_output.stderr.strip()
@@ -530,7 +530,7 @@ def sigma_metadata(sigma_raw, sigma, play_id):
     product = sigma['logsource']['product'] if 'product' in sigma['logsource'] else 'none'
 
     esquery = subprocess.run(["sigmac", "-t", "elastalert", "-c", "playbook/sysmon.yml",
-                                    "-c", "playbook/securityonion-baseline.yml", "--backend-option", "keyword_whitelist=source.ip,destination.ip,source.port,destination.port", "--backend-option", "keyword_field=.keyword", "--backend-option", "analyzed_sub_field_name=.security", "--backend-option", "wildcard_use_keyword=false", temp_file.name],
+                                    "-c", "playbook/securityonion-baseline.yml", "--backend-option", "keyword_whitelist=source.ip,destination.ip,source.port,destination.port,message,rule.uuid", "--backend-option", "keyword_field=.keyword", "--backend-option", "analyzed_sub_field_name=.security", "--backend-option", "wildcard_use_keyword=false", temp_file.name],
                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='ascii')
 
     ea_config = re.sub(r'alert:\n.*filter:\n', 'filter:\n', esquery.stdout.strip(), flags=re.S)


### PR DESCRIPTION
Sets sigmac to use .keyword field for message & rule.uuid fields.