### PR TITLE
eliminate two PIDs in so-steno 

### DIFF
--- a/so-steno/files/so-steno.sh
+++ b/so-steno/files/so-steno.sh
@@ -5,4 +5,4 @@
 
 chown -R 941:939 /etc/stenographer/certs
 
-runuser -l stenographer -c '/usr/bin/stenographer --syslog=false >> /var/log/stenographer/stenographer.log 2>&1' 
+exec runuser -l stenographer -c 'exec >> /var/log/stenographer/stenographer.log 2>&1 /usr/bin/stenographer --syslog=false' 


### PR DESCRIPTION
Small change to so-steno launch script to eliminate two bash processes that just hang around waiting for their children to exit before exiting themselves.

This is untested, as I don't have a full build setup.  I recommend testing by verifying proper function of stenographer after startup as well as proper shutdown when running so-pcap-stop and entries in logfile.  The change can be seen by running 'docker top so-steno' and comparing the count of running processes.