### PR TITLE
correct flag to disable syslog from stenographer

### DIFF
--- a/so-steno/files/so-steno.sh
+++ b/so-steno/files/so-steno.sh
@@ -5,4 +5,4 @@
 
 chown -R 941:939 /etc/stenographer/certs
 
-runuser -l stenographer -c '/usr/bin/stenographer -syslog=false >> /var/log/stenographer/stenographer.log 2>&1' 
+runuser -l stenographer -c '/usr/bin/stenographer --syslog=false >> /var/log/stenographer/stenographer.log 2>&1' 


### PR DESCRIPTION
Need 2 `-`s