### PR TITLE
FIX: Mapping of TargetUserName is missing

### DIFF
--- a/so-soctopus/so-soctopus/playbook/securityonion-baseline.yml
+++ b/so-soctopus/so-soctopus/playbook/securityonion-baseline.yml
@@ -137,6 +137,7 @@ fieldmappings:
     SubjectUserName: user.name
     TargetFilename: file.target
     TargetImage: winlog.event_data.TargetImage
+    TargetUserName: winlog.event_data.TargetUserName
     TargetObject: winlog.event_data.TargetObject
     TicketEncryptionType: winlog.event_data.TicketEncryptionType
     TicketOptions: winlog.event_data.TicketOptions

--- a/so-soctopus/so-soctopus/playbook/securityonion-baseline.yml
+++ b/so-soctopus/so-soctopus/playbook/securityonion-baseline.yml
@@ -137,8 +137,8 @@ fieldmappings:
     SubjectUserName: user.name
     TargetFilename: file.target
     TargetImage: winlog.event_data.TargetImage
-    TargetUserName: winlog.event_data.TargetUserName
     TargetObject: winlog.event_data.TargetObject
+    TargetUserName: winlog.event_data.TargetUserName
     TicketEncryptionType: winlog.event_data.TicketEncryptionType
     TicketOptions: winlog.event_data.TicketOptions
     User: user.name


### PR DESCRIPTION
Added TargetUserName mapping to fix some playbooks.
(For example Admin User Remote Logon)