### PR TITLE
Zeek 6 upgrade

### DIFF
--- a/so-zeek/Dockerfile
+++ b/so-zeek/Dockerfile
@@ -13,11 +13,11 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM ghcr.io/security-onion-solutions/oraclelinux:9 as builder 
+FROM ghcr.io/security-onion-solutions/oraclelinux:9 as builder
 
 RUN dnf -y install dnf-plugins-core && \
     dnf config-manager --enable ol9_codeready_builder && \
-    dnf update -y && \ 
+    dnf update -y && \
     dnf -y install epel-release bash libpcap iproute wget cmake swig && \
     dnf -y install jemalloc numactl libnl3 libdnet gdb git && \
     dnf -y install libpcap-devel openssl-devel zlib-devel jemalloc-devel python3-devel kernel-devel kernel-headers && \
@@ -41,7 +41,7 @@ RUN dnf -y install perl && \
 
 WORKDIR /
 
-ENV ZEEKVER=5.0.10
+ENV ZEEKVER=6.0.1
 ARG BUILD_TYPE=Release
 
 RUN mkdir /zeekbuild
@@ -51,12 +51,9 @@ WORKDIR /zeekbuild
 RUN wget https://download.zeek.org/zeek-$ZEEKVER.tar.gz && tar zxvf zeek-$ZEEKVER.tar.gz
 RUN cd zeek-$ZEEKVER && \
     ./configure --prefix=/opt/zeek --spooldir=/nsm/zeek/spool --logdir=/nsm/zeek/logs --enable-jemalloc --build-type=$BUILD_TYPE --with-openssl=/usr/local/ssl && \
-    time make -j4 && time make install && \
-    fips-mode-setup --enable
+    time make -j4 && time make install
 RUN /opt/zeek/bin/zkg install --force ja3 && \
     /opt/zeek/bin/zkg install --force hassh && \
-    /opt/zeek/bin/zkg install --force https://github.com/TOoSmOotH/zeek-af_packet-plugin --version=master && \
-    /opt/zeek/bin/zkg install --force zeek-community-id && \
     /opt/zeek/bin/zkg install --force --skiptests https://github.com/mmguero-dev/bzar --version=master && \
     /opt/zeek/bin/zkg install --force --skiptests icsnpp-bacnet && \
     /opt/zeek/bin/zkg install --force --skiptests icsnpp-bsap && \
@@ -68,11 +65,11 @@ RUN /opt/zeek/bin/zkg install --force ja3 && \
     /opt/zeek/bin/zkg install --force --skiptests icsnpp-modbus && \
     git clone https://github.com/cisagov/icsnpp-s7comm && \
     /opt/zeek/bin/zkg install --force --skiptests icsnpp-s7comm && \
-    git clone https://github.com/amzn/zeek-plugin-profinet && \
-    /opt/zeek/bin/zkg install --force --skiptests zeek-plugin-profinet && \
-    git clone https://github.com/amzn/zeek-plugin-tds && \
-    /opt/zeek/bin/zkg install --force --skiptests zeek-plugin-tds && \
-    /opt/zeek/bin/zkg install --force --skiptests zeek-spicy-wireguard && \ 
+    #git clone https://github.com/amzn/zeek-plugin-profinet && \
+    #/opt/zeek/bin/zkg install --force --skiptests zeek-plugin-profinet && \
+    #git clone https://github.com/amzn/zeek-plugin-tds && \
+    #/opt/zeek/bin/zkg install --force --skiptests zeek-plugin-tds && \
+    /opt/zeek/bin/zkg install --force --skiptests zeek-spicy-wireguard && \
     /opt/zeek/bin/zkg install --force --skiptests zeek-spicy-stun && \
     /opt/zeek/bin/zkg install --force --skiptests https://github.com/iamckn/oui-logging && \
     /bin/python3 /opt/zeek/share/zeek/site/oui-logging/oui.py /opt/zeek/share/zeek/site/oui-logging/oui.dat && \
@@ -84,11 +81,11 @@ RUN groupadd --gid 937 zeek  && \
     chown -R 937:937 /opt/zeek && \
     chown -R 937:937 /nsm/zeek && \
     chown -R 937:937 /usr/local/ssl
-    
+
 FROM ghcr.io/security-onion-solutions/oraclelinux:9
 
 LABEL maintainer "Security Onion Solutions, LLC"
-LABEL description="Zeek running in a docker with AF_Packet 3.2.0 for use with Security Onion"
+LABEL description="Zeek running in docker for use with Security Onion"
 
 # Common CentOS layer
 RUN dnf update -y && \
@@ -106,7 +103,7 @@ COPY --from=builder /usr/local/ssl/ /usr/local/ssl
 # Copy over the entry script.
 COPY files/zeek.sh /usr/local/sbin/zeek.sh
 RUN chmod +x /usr/local/sbin/zeek.sh
-RUN rpm -Uvh --nofiledigest --nodigest https://github.com/axellioinc/fx-libpcap/releases/download/fxlibpcap-1.9.1/fx-libpcap-1.9.1-1.el7.x86_64.rpm
+RUN rpm -Uvh https://github.com/axellioinc/fx-libpcap/releases/download/fxlibpcap-1.9.1/fx-libpcap-1.9.1-1.el7.x86_64.rpm
 
 HEALTHCHECK --interval=10m --timeout=2m CMD /opt/zeek/bin/zeekctl status || (kill -s 15 -1 && (sleep 30; kill -s 9 -1))
 


### PR DESCRIPTION
Removes external af_packet & zeek-community-id plugins (Replaced by built-in functionality). Removes plugin-tds & plugin-profinet due to failing to build on Zeek 6. Pending two PRs for patch