### PR TITLE
Add stenographer logging

### DIFF
--- a/so-steno/files/so-steno.sh
+++ b/so-steno/files/so-steno.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+exec >> /var/log/stenographer/stenographer.log 2>&1
 
 # Generate the keys if they have not been already
 /usr/bin/stenokeys.sh 941 939
 
 chown -R 941:939 /etc/stenographer/certs
 
-runuser -l stenographer -c '/usr/bin/stenographer --syslog=false >> /var/log/stenographer/stenographer.log 2>&1' 
+exec runuser -l stenographer -c 'exec /usr/bin/stenographer -v 1 --syslog=false' 


### PR DESCRIPTION
Adds the '-v 1' option when launching stenographer to enable verbose level 1 on stenographer.  Stenotype logging was already enabled via config.

Also moves the stdio redirect to the top of the script so that stenokeys.sh output goes to logfile as well instead of going to docker logs output.

Also adds a couple of strategic exec commands to avoid intermediate shells before and after runuser.

Replaces PR #509.  Related to https://github.com/Security-Onion-Solutions/securityonion/discussions/12184