### PR TITLE
Add bash

### DIFF
--- a/so-elastic-fleet-package-registry/Dockerfile
+++ b/so-elastic-fleet-package-registry/Dockerfile
@@ -16,6 +16,9 @@ ARG VERSION
 
 FROM docker.elastic.co/package-registry/distribution:$VERSION as original_image
 
+# Add bash because it is not included in the new default base image of wolfi-base (default sh shell)
+RUN apk add --no-cache bash coreutils
+
 # Remove unsupported packages
 COPY scripts /scripts
 RUN chmod +x /scripts/supported-integrations.sh && bash /scripts/supported-integrations.sh && rm -rf /scripts


### PR DESCRIPTION
The new wolfi-base doesn't include bash, so we need to add it. 