### PR TITLE
Version changes for Strelka images

### DIFF
--- a/so-strelka-filestream/Dockerfile
+++ b/so-strelka-filestream/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/security-onion-solutions/golang:1.21.5-alpine AS build
+FROM ghcr.io/security-onion-solutions/golang:1.22.6-alpine AS build
 LABEL maintainer "Security Onion Solutions, LLC"
 ARG STRELKA_RELEASE_VERSION=0.24.01.18
 
 RUN CGO_ENABLED=0 go install github.com/target/strelka/src/go/cmd/strelka-filestream@$STRELKA_RELEASE_VERSION
 
-FROM ghcr.io/security-onion-solutions/alpine
+FROM ghcr.io/security-onion-solutions/alpine:3.20.2
 COPY --from=build /go/bin/strelka-filestream /usr/local/bin/
 RUN addgroup -g 939 strelka && \
     adduser -u 939 -G strelka strelka --disabled-password \

--- a/so-strelka-frontend/Dockerfile
+++ b/so-strelka-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/security-onion-solutions/golang:1.21.5-alpine AS build
+FROM ghcr.io/security-onion-solutions/golang:1.22.6-alpine AS build
 LABEL maintainer "Security Onion Solutions, LLC"
 ARG STRELKA_RELEASE_VERSION=0.24.01.18
 
@@ -10,7 +10,7 @@ RUN apk add openssl-dev \
     librdkafka-dev && \
     CGO_ENABLED=1 go install -tags musl github.com/target/strelka/src/go/cmd/strelka-frontend@$STRELKA_RELEASE_VERSION
 
-FROM ghcr.io/security-onion-solutions/alpine
+FROM ghcr.io/security-onion-solutions/alpine:3.20.2
 
 COPY --from=build /go/bin/strelka-frontend /usr/local/bin/
 

--- a/so-strelka-manager/Dockerfile
+++ b/so-strelka-manager/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/security-onion-solutions/golang:1.21.5-alpine AS build
+FROM ghcr.io/security-onion-solutions/golang:1.22.6-alpine AS build
 LABEL maintainer "Security Onion Solutions, LLC"
 ARG STRELKA_RELEASE_VERSION=0.24.01.18
 
 RUN CGO_ENABLED=0 go install github.com/target/strelka/src/go/cmd/strelka-manager@$STRELKA_RELEASE_VERSION
 
-FROM ghcr.io/security-onion-solutions/alpine
+FROM ghcr.io/security-onion-solutions/alpine:3.20.2
 COPY --from=build /go/bin/strelka-manager /usr/local/bin/
 RUN addgroup -g 939 strelka && \
     adduser -u 939 -G strelka strelka --disabled-password \


### PR DESCRIPTION
Update:

- `golang:1.21.5-alpine` to `golang:1.22.6-alpine`
- `alpine` to `alpine:3.20.2`

For the following images:

- so-strelka-filestream
- so-strelka-frontend
- so-strelka-manager