### PR TITLE
remove beta hpe_aruba_cx integration

### DIFF
--- a/so-elastic-fleet-package-registry/scripts/unsupported-integrations.txt
+++ b/so-elastic-fleet-package-registry/scripts/unsupported-integrations.txt
@@ -1,2 +1,3 @@
 apm
 cloud_security_posture
+hpe_aruba_cx


### PR DESCRIPTION
when attempting to install on 8.18.3 error shows
```
parse_exception Root causes: parse_exception: [skip_if_unlicensed] current license is non-compliant for [redact_processor]
```

Integration requirements do not specify the need for any elastic license