### PR TITLE
Add custom Zeek package loading to entrypoint

### DIFF
--- a/so-zeek/files/zeek.sh
+++ b/so-zeek/files/zeek.sh
@@ -2,6 +2,17 @@
 
 setcap cap_net_raw,cap_net_admin=eip /opt/zeek/bin/zeek
 setcap cap_net_raw,cap_net_admin=eip /opt/zeek/bin/capstats
+
+# Install custom Zeek packages from /opt/so/conf/zeek/zkg
+CUSTOM_PKG_DIR="/opt/so/conf/zeek/zkg"
+if [ -d "$CUSTOM_PKG_DIR" ]; then
+  for pkg in "$CUSTOM_PKG_DIR"/*/; do
+    [ -d "$pkg" ] || continue
+    echo "Installing custom Zeek package: $pkg"
+    /opt/zeek/bin/zkg install --force --skiptests "$pkg"
+  done
+fi
+
 runuser zeek -c '/opt/zeek/bin/zeekctl deploy'
 
 trap "runuser zeek -c '/opt/zeek/bin/zeekctl stop'" SIGTERM


### PR DESCRIPTION
## Summary
- Install custom Zeek packages from `/opt/so/conf/zeek/zkg` on container startup, before `zeekctl deploy`
- Allows users to persist custom Zeek packages across container recreations by mounting a volume with package directories
- Skips gracefully if the directory doesn't exist (no volume mounted)

## Test plan
- [ ] Build and run the container without mounting anything to `/opt/so/conf/zeek/zkg` — should start normally with no errors
- [ ] Mount a directory containing a valid Zeek package and verify it gets installed on startup via container logs