### PR TITLE
Add git and pip3 to zeek runtime image for zkg dependencies

### DIFF
--- a/so-zeek/Dockerfile
+++ b/so-zeek/Dockerfile
@@ -94,7 +94,7 @@ LABEL description="Zeek running in docker for use with Security Onion"
 # Common Oracle layer, Packages specific to container, User configuration
 RUN dnf update -y && dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm bash libpcap iproute && \
     dnf clean all && rm -rf /var/cache/dnf/* && \
-    dnf -y install findutils jemalloc numactl libnl3 libdnet gdb libunwind-devel python3 python3-pip && \
+    dnf -y install findutils jemalloc numactl libnl3 libdnet gdb libunwind-devel python3 python3-pip git && \
     dnf config-manager --enable ubi-9-codeready-builder-rpms && \
     dnf -y install libnghttp2-devel brotli-devel zeromq-devel && \
     dnf config-manager --disable ubi-9-codeready-builder-rpms && \


### PR DESCRIPTION
## Summary
- Adds `python3-pip` to the zeek runtime image so `pip3` is available
- Adds `git` to the zeek runtime image, required by GitPython at runtime

## Test plan
- [x] Verify zeek image builds successfully
- [ ] Verify `zkg` can install custom packages without import errors