### PR TITLE
Fix zkg runtime: run as zeek user with safe.directory

### DIFF
--- a/so-zeek/files/zeek.sh
+++ b/so-zeek/files/zeek.sh
@@ -9,8 +9,8 @@ if [ -d "$CUSTOM_PKG_DIR" ]; then
   for pkg in "$CUSTOM_PKG_DIR"/*/; do
     [ -d "$pkg" ] || continue
     echo "Installing custom Zeek package: $pkg"
-    git config --global --add safe.directory "$pkg"
-    /opt/zeek/bin/zkg install --force --skiptests "$pkg"
+    runuser zeek -c "git config --global --add safe.directory \"$pkg\""
+    runuser zeek -c "/opt/zeek/bin/zkg install --force --skiptests \"$pkg\""
   done
 fi
 

--- a/so-zeek/files/zeek.sh
+++ b/so-zeek/files/zeek.sh
@@ -9,6 +9,7 @@ if [ -d "$CUSTOM_PKG_DIR" ]; then
   for pkg in "$CUSTOM_PKG_DIR"/*/; do
     [ -d "$pkg" ] || continue
     echo "Installing custom Zeek package: $pkg"
+    git config --global --add safe.directory "$pkg"
     /opt/zeek/bin/zkg install --force --skiptests "$pkg"
   done
 fi


### PR DESCRIPTION
## Summary
- Marks custom package directories as git `safe.directory` to fix ownership mismatch errors
- Runs `zkg install` as the `zeek` user to preserve correct file ownership for `zeekctl deploy`

## Test plan
- [ ] Verify zeek image builds successfully
- [ ] Verify `zkg install` succeeds for custom local packages without git errors
- [ ] Verify `zeekctl deploy` succeeds after package installation