### PR TITLE
Fix gitconfig permission for zkg custom package install

### DIFF
--- a/so-zeek/files/zeek.sh
+++ b/so-zeek/files/zeek.sh
@@ -9,8 +9,8 @@ if [ -d "$CUSTOM_PKG_DIR" ]; then
   for pkg in "$CUSTOM_PKG_DIR"/*/; do
     [ -d "$pkg" ] || continue
     echo "Installing custom Zeek package: $pkg"
-    runuser zeek -c "git config --global --add safe.directory \"$pkg\""
-    runuser zeek -c "/opt/zeek/bin/zkg install --force --skiptests \"$pkg\""
+    git config --global --add safe.directory "$pkg"
+    runuser zeek -c "GIT_CONFIG_GLOBAL=/root/.gitconfig /opt/zeek/bin/zkg install --force --skiptests \"$pkg\""
   done
 fi
 


### PR DESCRIPTION
## Summary
- Writes git `safe.directory` config as root (writable `/root/.gitconfig`) instead of as zeek user
- Passes `GIT_CONFIG_GLOBAL=/root/.gitconfig` to the zeek-user `zkg` process so it inherits the safe.directory setting

## Test plan
- [ ] Verify zeek image builds successfully
- [ ] Verify `zkg install` succeeds without gitconfig permission errors