### PR TITLE
Add so-postgres container

### DIFF
--- a/so-postgres/Dockerfile
+++ b/so-postgres/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update -y && \
     apt install -y \
       postgresql-17-pgvector \
       postgresql-17-cron \
-      postgresql-17-pg-partman && \
+      postgresql-17-partman && \
     apt clean -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Adds Dockerfile and entrypoint for so-postgres container (PostgreSQL 17)
- Includes pgvector, pg_cron, and pg_partman extensions
- Custom entrypoint with log redirection, healthcheck, GID 939 alignment
- Loads postgresql.conf from /conf for TLS and tunable settings

## Test plan
- [ ] Build the container: `docker build -t so-postgres:test so-postgres/`
- [ ] Verify healthcheck: `docker run -d so-postgres:test && docker inspect --format='{{.State.Health.Status}}'`
- [ ] Verify extensions are installed: `psql -c "SELECT * FROM pg_available_extensions WHERE name IN ('vector','pg_cron','pg_partman','pgcrypto');"`