### PR TITLE
Fix postgres UID to match Salt directory ownership

### DIFF
--- a/so-postgres/Dockerfile
+++ b/so-postgres/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 5432
 
 RUN mkdir -p /log /conf
 
-RUN groupmod -g 939 postgres
+RUN usermod -u 939 postgres && groupmod -g 939 postgres
 
 RUN apt update -y && \
     apt install -y \


### PR DESCRIPTION
## Summary
- Add `usermod -u 939 postgres` alongside the existing `groupmod -g 939 postgres`
- Without this, the postgres process can't read/write `/nsm/postgres` which Salt creates as 939:939
- Fixes "FATAL: could not open file global/pg_filenode.map: Permission denied"

## Test plan
- [ ] Rebuild container: `docker build -t so-postgres:test so-postgres/`
- [ ] Clean data dir: `sudo rm -rf /nsm/postgres/*`
- [ ] Restart container — initdb should succeed
- [ ] Verify: `ls -la /nsm/postgres/` shows 939:939 ownership