### PR TITLE
Resolve SO_POSTGRES_PASS_FILE in so-postgres entrypoint

### DIFF
--- a/so-postgres/entrypoint.sh
+++ b/so-postgres/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Resolve *_FILE secret env vars before launching the upstream entrypoint, so
+# the upstream handler sees POSTGRES_PASSWORD (from POSTGRES_PASSWORD_FILE) and
+# our auth step below sees SO_POSTGRES_PASS (from SO_POSTGRES_PASS_FILE).
+# Docker-standard: file contents are treated as the secret with no trimming
+# beyond a single trailing newline, matching the upstream postgres image.
+if [ -z "${SO_POSTGRES_PASS:-}" ] && [ -n "${SO_POSTGRES_PASS_FILE:-}" ] && [ -r "$SO_POSTGRES_PASS_FILE" ]; then
+    SO_POSTGRES_PASS="$(< "$SO_POSTGRES_PASS_FILE")"
+    export SO_POSTGRES_PASS
+fi
+
 # Start postgres via the official entrypoint in the background
 docker-entrypoint.sh "$@" &>> /log/postgres.log &
 PG_PID=$!


### PR DESCRIPTION
## Summary
- so-postgres/entrypoint.sh now resolves SO_POSTGRES_PASS_FILE → SO_POSTGRES_PASS before launching the upstream docker-entrypoint.sh, mirroring the upstream POSTGRES_PASSWORD_FILE handling.
- Lets Salt deliver the SOC app-user password via a mounted 0600 secret file instead of a plaintext environment variable.
- PR also carries the other feature/postgres commits already on that branch (ES 9.3.3, ElastAlert2 2.30, integration registry updates) picked up via the merge from 3/dev.

## Test plan
- [ ] Build so-postgres image, verify container starts with `POSTGRES_PASSWORD_FILE` and `SO_POSTGRES_PASS_FILE` set and no plaintext secrets in `docker inspect`
- [ ] App-user SQL role is created/updated on first boot and on subsequent boots with rotated password