### PR TITLE
add -verify and -verify-timeout flags to installer. Ensures that the …

### DIFF
--- a/so-elastic-agent-builder/source/constants_darwin_amd64.go
+++ b/so-elastic-agent-builder/source/constants_darwin_amd64.go
@@ -8,3 +8,4 @@ import (
 var agentFiles []byte
 
 const installPath = "/Library/Elastic/SO/"
+const installedAgentPath = "/Library/Elastic/Agent/elastic-agent"

--- a/so-elastic-agent-builder/source/constants_darwin_arm64.go
+++ b/so-elastic-agent-builder/source/constants_darwin_arm64.go
@@ -8,3 +8,4 @@ import (
 var agentFiles []byte
 
 const installPath = "/Library/Elastic/SO/"
+const installedAgentPath = "/Library/Elastic/Agent/elastic-agent"

--- a/so-elastic-agent-builder/source/constants_linux.go
+++ b/so-elastic-agent-builder/source/constants_linux.go
@@ -8,3 +8,4 @@ import (
 var agentFiles []byte
 
 const installPath = "/opt/Elastic/SO/"
+const installedAgentPath = "/opt/Elastic/Agent/elastic-agent"

--- a/so-elastic-agent-builder/source/constants_windows.go
+++ b/so-elastic-agent-builder/source/constants_windows.go
@@ -8,3 +8,4 @@ import (
 var agentFiles []byte
 
 const installPath = "C:\\Program Files\\Elastic\\SO\\"
+const installedAgentPath = "C:\\Program Files\\Elastic\\Agent\\elastic-agent.exe"

--- a/so-elastic-agent-builder/source/so-elastic-agent.go
+++ b/so-elastic-agent-builder/source/so-elastic-agent.go
@@ -32,7 +32,9 @@ var fleetHostFlag string
 var enrollmentToken, enrollmentTokenFlag string
 var delayEnrollFlag bool
 var forceFlag bool
+var verifyFlag bool
 var timeoutFlag time.Duration
+var verifyTimeoutFlag time.Duration
 
 func check(err error, context string) {
 	if err != nil {
@@ -75,6 +77,68 @@ func extractTarGz(sourceFile string, destDir string) error {
 	return utils.ExtractTarGz(sourceFile, destDir)
 }
 
+func elasticAgentStatusHealthy(output string) bool {
+	checkElasticAgentStatus := false
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.ToUpper(strings.TrimSpace(line))
+		line = strings.ReplaceAll(line, " ", "")
+
+		if strings.Contains(line, "ELASTIC-AGENT") {
+			checkElasticAgentStatus = true
+			continue
+		}
+
+		if checkElasticAgentStatus && strings.Contains(line, "STATUS:") {
+			return strings.Contains(line, "(HEALTHY)")
+		}
+
+	}
+
+	return false
+}
+
+func waitForElasticAgentHealthy(ctx context.Context) error {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	var lastOutput string
+	for {
+		cmd := exec.CommandContext(ctx, installedAgentPath, "status")
+		output, err := cmd.CombinedOutput()
+		lastOutput = string(output)
+		if err == nil && elasticAgentStatusHealthy(lastOutput) {
+			statusLogs("Elastic Agent appears healthy: " + lastOutput)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for Elastic Agent to become healthy: %s", strings.TrimSpace(lastOutput))
+		case <-ticker.C:
+		}
+	}
+}
+
+func uninstallElasticAgent() {
+	statusLogs("Uninstalling Elastic Agent after failed verification")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, installedAgentPath, "uninstall", "--force")
+	output, err := cmd.CombinedOutput()
+	if len(output) > 0 {
+		statusLogs("Elastic Agent uninstall output: " + string(output))
+	}
+	if err != nil {
+		log.WithFields(log.Fields{
+			"Context":       "Elastic Agent uninstall failed after verification failure",
+			"Error Details": err,
+		}).Error("Installation Progress")
+	}
+}
+
 func InitLogging(logFilename string, logLevel string) (*os.File, error) {
 	logFile, err := os.OpenFile(logFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err == nil {
@@ -104,7 +168,9 @@ func main() {
 	flag.StringVar(&fleetHostFlag, "fleet", "", "Override default Fleet Host")
 	flag.BoolVar(&delayEnrollFlag, "delay-enroll", false, "Add delay enroll flag")
 	flag.BoolVar(&forceFlag, "force", false, "Add force flag")
+	flag.BoolVar(&verifyFlag, "verify", false, "Wait for newly installed Elastic Agent to report healthy status")
 	flag.DurationVar(&timeoutFlag, "timeout", 5*time.Minute, "Set the timeout duration (default: 5 minutes)")
+	flag.DurationVar(&verifyTimeoutFlag, "verify-timeout", 3*time.Minute, "How long to wait for Elastic Agent to report a healthy status (default: 3 minutes)")
 	flag.Parse()
 
 	if enrollmentTokenFlag != "" {
@@ -216,6 +282,19 @@ func main() {
 	output, err := cmd.CombinedOutput()
 	check(err, string(output))
 	statusLogs(string(output))
+
+	if verifyFlag {
+		statusLogs("Verifying Elastic Agent status")
+		ctx, cancel = context.WithTimeout(context.Background(), verifyTimeoutFlag)
+		defer cancel()
+
+		err = waitForElasticAgentHealthy(ctx)
+		if err != nil {
+			uninstallElasticAgent()
+		}
+		check(err, "Installed Elastic Agent did not report healthy status within the verification timeout")
+	}
+
 	cleanupInstall()
 
 	statusLogs("Elastic Agent installation completed")


### PR DESCRIPTION
Looks at ```elastic-agent status``` output and checks if the  'elastic-agent' component reports as 'HEALTHY'

SO-Elastic-Agent_Installer.log
```
timestamp=2026-05-14T21:55:36.931146683Z level=info message="Installation Progress" Status="Executing Elastic Agent installer"
timestamp=2026-05-14T21:55:36.931335762Z level=info message="Installation Progress" Status="Executing the following: ./so-elastic-agent_source/elastic-agent/elastic-agent install --url=https://10.67.100.70:8220 --enrollment-token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== --certificate-authorities=/opt/Elastic/SO/soca.crt -n --force"
timestamp=2026-05-14T21:55:39.570948427Z level=info message="Installation Progress" Status="Installing in non-interactive mode.\n\r[    ] Copying install files  [0s] \r                                   \r\r[====] Successfully copied files  [0s] \r                                       \r\r[====] Installing service  [0s] \r                                       \r\r[    ] Installed service  [0s] \r                                       \r\r[    ] Starting Service  [0s] \r                                       \r\r[   =] Service Started  [0s] Elastic Agent successfully installed, starting enrollment.\n\r                                       \r\r[   =] Enrolling Elastic Agent with Fleet  [0s] \r                                                \r\r[   =] Waiting For Enroll...  [0s] {\"log.level\":\"info\",\"@timestamp\":\"2026-05-14T21:55:38.491Z\",\"log.origin\":{\"function\":\"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.EnrollWithBackoff\",\"file.name\":\"enroll/enroll.go\",\"file.line\":86},\"message\":\"Starting enrollment to URL: https://10.67.100.70:8220/\",\"ecs.version\":\"1.6.0\"}\n{\"log.level\":\"info\",\"@timestamp\":\"2026-05-14T21:55:39.560Z\",\"log.origin\":{\"function\":\"github.com/elastic/elastic-agent/internal/pkg/agent/cmd.(*enrollCmd).daemonReloadWithBackoff\",\"file.name\":\"cmd/enroll_cmd.go\",\"file.line\":395},\"message\":\"Restarting agent daemon, attempt 0\",\"ecs.version\":\"1.6.0\"}\n{\"log.level\":\"info\",\"@timestamp\":\"2026-05-14T21:55:39.562Z\",\"log.origin\":{\"function\":\"github.com/elastic/elastic-agent/internal/pkg/agent/cmd.(*enrollCmd).Execute\",\"file.name\":\"cmd/enroll_cmd.go\",\"file.line\":205},\"message\":\"Successfully triggered restart on running Elastic Agent.\",\"ecs.version\":\"1.6.0\"}\nSuccessfully enrolled the Elastic Agent.\n\r                                                \r\r[   =] Enroll Completed  [2s] \r                                                \r\r[   =] Done  [2s] \r                                                \r\r[   =] Done  [2s] \nElastic Agent has been successfully installed.\n"
timestamp=2026-05-14T21:55:39.570996867Z level=info message="Installation Progress" Status="Verifying Elastic Agent status"
timestamp=2026-05-14T21:55:49.638806399Z level=info message="Installation Progress" Status="Elastic Agent appears healthy: ┌─ fleet\n│  └─ status: (HEALTHY) Connected\n└─ elastic-agent\n   └─ status: (HEALTHY) Running\n"
timestamp=2026-05-14T21:55:49.639073787Z level=info message="Installation Progress" Status="Starting cleanup of installation files"
timestamp=2026-05-14T21:55:49.714523064Z level=info message="Installation Progress" Status="Elastic Agent installation completed"
```

Example of failing installer when healthy status wasn't seen within timeout

```
timestamp=2026-05-14T22:36:10.842998181Z level=info message="Installation Progress" Status="Executing the following: ./so-elastic-agent_source/elastic-agent/elastic-agent install --url=https://10.67.100.70:8220 --enrollment-token=YkZXSXNKWUJ3ZzFrNVNlcHdiRXk6R2lGWHcyMDlTYkNBOWpDNThBeHVDZw== --certificate-authorities=/opt/Elastic/SO/soca.crt -n --force"
timestamp=2026-05-14T22:36:13.398147643Z level=info message="Installation Progress" Status="Installing in non-interactive mode.\n\r[    ] Copying install files  [0s] \r                                   \r\r[=== ] Successfully copied files  [0s] \r                                       \r\r[=== ] Installing service  [0s] \r                                       \r\r[  ==] Installed service  [1s] \r                                       \r\r[  ==] Starting Service  [1s] \r                                       \r\r[  ==] Service Started  [1s] Elastic Agent successfully installed, starting enrollment.\n\r                                       \r\r[  ==] Enrolling Elastic Agent with Fleet  [1s] \r                                                \r\r[  ==] Waiting For Enroll...  [1s] {\"log.level\":\"info\",\"@timestamp\":\"2026-05-14T22:36:12.554Z\",\"log.origin\":{\"function\":\"github.com/elastic/elastic-agent/internal/pkg/agent/application/enroll.EnrollWithBackoff\",\"file.name\":\"enroll/enroll.go\",\"file.line\":86},\"message\":\"Starting enrollment to URL: https://10.67.100.70:8220/\",\"ecs.version\":\"1.6.0\"}\n{\"log.level\":\"info\",\"@timestamp\":\"2026-05-14T22:36:13.387Z\",\"log.origin\":{\"function\":\"github.com/elastic/elastic-agent/internal/pkg/agent/cmd.(*enrollCmd).daemonReloadWithBackoff\",\"file.name\":\"cmd/enroll_cmd.go\",\"file.line\":395},\"message\":\"Restarting agent daemon, attempt 0\",\"ecs.version\":\"1.6.0\"}\n{\"log.level\":\"info\",\"@timestamp\":\"2026-05-14T22:36:13.389Z\",\"log.origin\":{\"function\":\"github.com/elastic/elastic-agent/internal/pkg/agent/cmd.(*enrollCmd).Execute\",\"file.name\":\"cmd/enroll_cmd.go\",\"file.line\":205},\"message\":\"Successfully triggered restart on running Elastic Agent.\",\"ecs.version\":\"1.6.0\"}\nSuccessfully enrolled the Elastic Agent.\n\r                                                \r\r[    ] Enroll Completed  [2s] \r                                                \r\r[    ] Done  [2s] \r                                                \r\r[    ] Done  [2s] \nElastic Agent has been successfully installed.\n"
timestamp=2026-05-14T22:36:13.398208813Z level=info message="Installation Progress" Status="Verifying Elastic Agent status"
timestamp=2026-05-14T22:36:23.4017801Z level=info message="Installation Progress" Status="Uninstalling Elastic Agent after failed verification"
timestamp=2026-05-14T22:36:29.650770496Z level=info message="Installation Progress" Status="Elastic Agent uninstall output: \r[    ] Stopping service  [0s] \r                              \r\r[  ==] Successfully stopped service  [5s] \r                                          \r\r[====] Stopping upgrade watcher; none found  [5s] \r                                                  \r\r[====] Removing service  [5s] \r                                                  \r\r[=   ] Successfully uninstalled service  [5s] \r                                                  \r\r[=   ] Removing install directory  [5s] \r                                                  \r\r[    ] Removed install directory  [5s] \r                                                  \r\r[    ] Attempting to notify Fleet of uninstall  [5s] \r                                                     \r\r[=== ] Successfully notified Fleet about uninstall  [6s] \r                                                         \r\r[=== ] Done  [6s] \r                                                         \r\r[=== ] Done  [6s] \nElastic Agent has been uninstalled.\n"
timestamp=2026-05-14T22:36:29.650834936Z level=error message="Installation Progress" Context="Installed Elastic Agent did not report healthy status within the verification timeout" ErrorDetails="timed out waiting for Elastic Agent to become healthy: ┌─ fleet\n│  └─ status: (HEALTHY) Connected\n└─ elastic-agent\n   └─ status: (STARTING) Waiting for initial configuration and composable variables"
timestamp=2026-05-14T22:36:29.650850326Z level=info message="Installation Progress" Status="Starting cleanup of installation files"

```