### PR TITLE
so-postgres: thin entrypoint, drop duplicated role provisioning (fixes fresh-init race)

### DIFF
--- a/so-postgres/entrypoint.sh
+++ b/so-postgres/entrypoint.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# Thin wrapper around the official postgres entrypoint: send all server output to
-# /log/postgres.log (bind-mounted to /opt/so/log/postgres on the host, rotated by
-# salt logrotate).
-#
-# Role/database/grant provisioning is owned entirely by the salt-managed
-# init-db.sh -- run on fresh init via /docker-entrypoint-initdb.d and reconciled
-# on every highstate by postgres.enabled (postgres_bootstrap_soc_db) -- so it is
-# intentionally NOT duplicated here. Doing it here as well raced init-db.sh on
-# fresh init and caused a duplicate-key CREATE ROLE failure.
-#
-# exec so postgres becomes PID 1 and receives signals (SIGTERM) directly.
+# Redirect the official postgres entrypoint's output to /log/postgres.log.
+# Role/DB provisioning lives in the salt-managed init-db.sh, not here.
 exec docker-entrypoint.sh "$@" >> /log/postgres.log 2>&1

--- a/so-postgres/entrypoint.sh
+++ b/so-postgres/entrypoint.sh
@@ -1,43 +1,14 @@
 #!/bin/bash
 
-# Resolve *_FILE secret env vars before launching the upstream entrypoint, so
-# the upstream handler sees POSTGRES_PASSWORD (from POSTGRES_PASSWORD_FILE) and
-# our auth step below sees SO_POSTGRES_PASS (from SO_POSTGRES_PASS_FILE).
-# Docker-standard: file contents are treated as the secret with no trimming
-# beyond a single trailing newline, matching the upstream postgres image.
-if [ -z "${SO_POSTGRES_PASS:-}" ] && [ -n "${SO_POSTGRES_PASS_FILE:-}" ] && [ -r "$SO_POSTGRES_PASS_FILE" ]; then
-    SO_POSTGRES_PASS="$(< "$SO_POSTGRES_PASS_FILE")"
-    export SO_POSTGRES_PASS
-fi
-
-# Start postgres via the official entrypoint in the background
-docker-entrypoint.sh "$@" &>> /log/postgres.log &
-PG_PID=$!
-
-# Wait for postgres to be ready
-for i in $(seq 1 30); do
-    if pg_isready -U postgres -q 2>/dev/null; then
-        break
-    fi
-    sleep 1
-done
-
-# Create or update the application user on every startup
-# This ensures the user exists and password stays in sync with the pillar
-if [ -n "$SO_POSTGRES_USER" ] && [ -n "$SO_POSTGRES_PASS" ] && pg_isready -U postgres -q 2>/dev/null; then
-    psql -U postgres -d "$POSTGRES_DB" -c "
-        DO \$\$
-        BEGIN
-            IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$SO_POSTGRES_USER') THEN
-                EXECUTE format('CREATE ROLE %I WITH LOGIN PASSWORD %L', '$SO_POSTGRES_USER', '$SO_POSTGRES_PASS');
-            ELSE
-                EXECUTE format('ALTER ROLE %I WITH PASSWORD %L', '$SO_POSTGRES_USER', '$SO_POSTGRES_PASS');
-            END IF;
-        END
-        \$\$;
-        GRANT ALL PRIVILEGES ON DATABASE \"$POSTGRES_DB\" TO \"$SO_POSTGRES_USER\";
-    " &>> /log/postgres.log
-fi
-
-# Wait for the postgres process
-wait $PG_PID
+# Thin wrapper around the official postgres entrypoint: send all server output to
+# /log/postgres.log (bind-mounted to /opt/so/log/postgres on the host, rotated by
+# salt logrotate).
+#
+# Role/database/grant provisioning is owned entirely by the salt-managed
+# init-db.sh -- run on fresh init via /docker-entrypoint-initdb.d and reconciled
+# on every highstate by postgres.enabled (postgres_bootstrap_soc_db) -- so it is
+# intentionally NOT duplicated here. Doing it here as well raced init-db.sh on
+# fresh init and caused a duplicate-key CREATE ROLE failure.
+#
+# exec so postgres becomes PID 1 and receives signals (SIGTERM) directly.
+exec docker-entrypoint.sh "$@" >> /log/postgres.log 2>&1


### PR DESCRIPTION
## Problem

`so-postgres/entrypoint.sh` created/updated the `so_postgres` role and granted database privileges on **every** container start. This duplicated the salt-managed `init-db.sh` — which does a **superset** (role upsert **plus** `GRANT ALL ON SCHEMA public`, `REVOKE/GRANT CONNECT`, and `so_telegraf` creation) — and raced it on fresh init:

- The upstream entrypoint runs `/docker-entrypoint-initdb.d/init-db.sh` (bind-mounted from salt) against the temporary init server.
- `entrypoint.sh`'s own `pg_isready`-gated upsert fired against that same temp server **concurrently**. Its `IF NOT EXISTS` check passed before init-db.sh committed, then its `CREATE ROLE` fired after → `duplicate key value violates unique constraint "pg_authid_rolname_index"` (SQLSTATE 23505).

Because `init-db.sh` runs only on fresh `PGDATA`, that abort left the cluster partially initialized: `so_postgres` existed but without the schema grants, so SOC failed with `permission denied for schema public`, and `so_telegraf` was missing. (Observed on a fresh standalone-azure install.)

The duplicated block was also a second **plaintext-password-in-log** vector — its role DDL had no `SET log_min_error_statement = panic` guard, and this is the code that redirects to `/log/postgres.log`.

## Change

Reduce `entrypoint.sh` to a thin wrapper that only redirects the upstream entrypoint's output to `/log/postgres.log`:

```bash
exec docker-entrypoint.sh "$@" >> /log/postgres.log 2>&1
```

Role/database/grant provisioning is now owned entirely by the salt-managed `init-db.sh` — run on fresh init via `docker-entrypoint-initdb.d`, and reconciled on every highstate by `postgres.enabled` (`postgres_bootstrap_soc_db`).

**Why safe:**
- Kills the race — on fresh init only `init-db.sh` touches the role; the salt reconcile runs only after `so-postgres-wait` confirms the *real* server is up (strictly after the temp-init phase).
- No functional regression — the role persists in `PGDATA`, and password changes flow pillar → secret file → `watch` restart inside a highstate, where the reconcile re-syncs.
- Removes the second log-leak vector.
- `exec` lets postgres run as PID 1 and receive SIGTERM directly.

## Coordination

Complementary to the salt-side self-heal in securityonion PR #16084 (which recovers already-broken / old-image clusters on highstate). This image change prevents the race on fresh installs and ships once `so_version` points at the rebuilt image.

## Testing

- `bash -n so-postgres/entrypoint.sh` passes.
- To validate on a build: run a fresh container with the salt env/binds and confirm `/log/postgres.log` is populated, `so_postgres` has `GRANT ALL ON SCHEMA public`, `so_telegraf` exists, and repeated restarts produce no `pg_authid_rolname_index` error and no plaintext password in the log.